### PR TITLE
Fix preedit position of initially scrolled content on macOS

### DIFF
--- a/core/src/input_method.rs
+++ b/core/src/input_method.rs
@@ -130,9 +130,9 @@ impl InputMethod {
         }
     }
 
-    /// Returns true if the [`InputMethod`] is open.
-    pub fn is_open(&self) -> bool {
-        matches!(self, Self::Open { .. })
+    /// Returns true if the [`InputMethod`] is allowed or open.
+    pub fn is_positioned(&self) -> bool {
+        matches!(self, Self::Allowed { .. } | Self::Open { .. })
     }
 }
 

--- a/core/src/input_method.rs
+++ b/core/src/input_method.rs
@@ -11,7 +11,10 @@ pub enum InputMethod<T = String> {
     /// No input method is allowed.
     Disabled,
     /// Input methods are allowed, but not open yet.
-    Allowed,
+    Allowed {
+        /// The position at which the input method dialog should be placed.
+        position: Point,
+    },
     /// Input method is open.
     Open {
         /// The position at which the input method dialog should be placed.
@@ -101,11 +104,11 @@ impl InputMethod {
     ///
     /// let mut ime = InputMethod::Disabled;
     ///
-    /// ime.merge(&InputMethod::<String>::Allowed);
-    /// assert_eq!(ime, InputMethod::Allowed);
+    /// ime.merge(&InputMethod::<String>::Allowed { position: Point::ORIGIN });
+    /// assert_eq!(ime, InputMethod::Allowed{ position: Point::ORIGIN });
     ///
     /// ime.merge(&InputMethod::<String>::Disabled);
-    /// assert_eq!(ime, InputMethod::Allowed);
+    /// assert_eq!(ime, InputMethod::Allowed{ position: Point::ORIGIN });
     ///
     /// ime.merge(&open);
     /// assert_eq!(ime, open);
@@ -117,7 +120,7 @@ impl InputMethod {
         match (&self, other) {
             (InputMethod::Open { .. }, _)
             | (
-                InputMethod::Allowed,
+                InputMethod::Allowed { .. },
                 InputMethod::None | InputMethod::Disabled,
             )
             | (InputMethod::Disabled, InputMethod::None) => {}
@@ -142,7 +145,9 @@ impl<T> InputMethod<T> {
         match self {
             Self::None => InputMethod::None,
             Self::Disabled => InputMethod::Disabled,
-            Self::Allowed => InputMethod::Allowed,
+            Self::Allowed { position } => InputMethod::Allowed {
+                position: *position,
+            },
             Self::Open {
                 position,
                 purpose,

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -729,7 +729,7 @@ where
                     _ => mouse::Cursor::Unavailable,
                 };
 
-                let had_input_method = shell.input_method().is_open();
+                let had_input_method = shell.input_method().is_positioned();
 
                 let translation =
                     state.translation(self.direction, bounds, content_bounds);
@@ -750,10 +750,12 @@ where
                 );
 
                 if !had_input_method {
-                    if let InputMethod::Open { position, .. } =
-                        shell.input_method_mut()
-                    {
-                        *position = *position + translation;
+                    match shell.input_method_mut() {
+                        InputMethod::Allowed { position }
+                        | InputMethod::Open { position, .. } => {
+                            *position = *position + translation;
+                        }
+                        _ => {}
                     }
                 }
             };

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -339,10 +339,6 @@ where
             return InputMethod::Disabled;
         };
 
-        let Some(preedit) = &state.preedit else {
-            return InputMethod::Allowed;
-        };
-
         let bounds = layout.bounds();
         let internal = self.content.0.borrow_mut();
 
@@ -362,6 +358,10 @@ where
 
         let position =
             cursor + translation + Vector::new(0.0, f32::from(line_height));
+
+        let Some(preedit) = &state.preedit else {
+            return InputMethod::Allowed { position };
+        };
 
         InputMethod::Open {
             position,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -406,10 +406,6 @@ where
             return InputMethod::Disabled;
         };
 
-        let Some(preedit) = &state.is_ime_open else {
-            return InputMethod::Allowed;
-        };
-
         let secure_value = self.is_secure.then(|| value.secure());
         let value = secure_value.as_ref().unwrap_or(value);
 
@@ -432,9 +428,14 @@ where
 
         let x = (text_bounds.x + cursor_x).floor() - scroll_offset
             + alignment_offset;
+        let position = Point::new(x, text_bounds.y + text_bounds.height);
+
+        let Some(preedit) = &state.is_ime_open else {
+            return InputMethod::Allowed { position };
+        };
 
         InputMethod::Open {
-            position: Point::new(x, text_bounds.y + text_bounds.height),
+            position,
             purpose: if self.is_secure {
                 input_method::Purpose::Secure
             } else {

--- a/winit/src/program/window_manager.rs
+++ b/winit/src/program/window_manager.rs
@@ -210,8 +210,13 @@ where
             InputMethod::Disabled => {
                 self.raw.set_ime_allowed(false);
             }
-            InputMethod::Allowed | InputMethod::Open { .. } => {
+            InputMethod::Allowed { position }
+            | InputMethod::Open { position, .. } => {
                 self.raw.set_ime_allowed(true);
+                self.raw.set_ime_cursor_area(
+                    LogicalPosition::new(position.x, position.y),
+                    LogicalSize::new(10, 10), // TODO?
+                );
             }
         }
 
@@ -221,11 +226,6 @@ where
             preedit,
         } = input_method
         {
-            self.raw.set_ime_cursor_area(
-                LogicalPosition::new(position.x, position.y),
-                LogicalSize::new(10, 10), // TODO?
-            );
-
             self.raw.set_ime_purpose(conversion::ime_purpose(purpose));
 
             if let Some(preedit) = preedit {


### PR DESCRIPTION
We also need changing the scrollable to fix the initial position when it is scrolled.

|before|after|
|-|-|
|<img width="637" alt="スクリーンショット 2025-02-10 22 06 55" src="https://github.com/user-attachments/assets/c68f94e6-15bd-4387-8628-e52f2d0ef597" />|<img width="639" alt="スクリーンショット 2025-02-10 22 12 32" src="https://github.com/user-attachments/assets/070571df-18eb-41ee-aec6-a188c67b2564" />|
